### PR TITLE
Fix bot startup error and zen mode button

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -282,7 +282,7 @@ export class GameClass {
         console.log('🎮 AI executing move:', move);
 
         // For now, just do a simple hard drop
-        const hardDropKey = this.settings.keybinds.hd;
+        const hardDropKey = this.settings.control.hdKey;
         console.log('🔽 AI executing hard drop with key:', hardDropKey);
         
         if (hardDropKey && this.controls) {
@@ -384,17 +384,17 @@ export class GameClass {
      * Get keycode for a move type
      */
     getMoveKeycode(move) {
-        const keybinds = this.settings.keybinds;
+        const keybinds = this.settings.control;
         
         switch(move) {
-            case 'left': return keybinds.left;
-            case 'right': return keybinds.right;
-            case 'cw': return keybinds.cw;
-            case 'ccw': return keybinds.ccw;
-            case '180': return keybinds.rotate180;
-            case 'sd': return keybinds.sd;
-            case 'hd': return keybinds.hd;
-            case 'hold': return keybinds.hold;
+            case 'left': return keybinds.leftKey;
+            case 'right': return keybinds.rightKey;
+            case 'cw': return keybinds.cwKey;
+            case 'ccw': return keybinds.ccwKey;
+            case '180': return keybinds.rotate180Key;
+            case 'sd': return keybinds.sdKey;
+            case 'hd': return keybinds.hdKey;
+            case 'hold': return keybinds.holdKey;
             default: return null;
         }
     }

--- a/src/mechanics/gamemode_extended.js
+++ b/src/mechanics/gamemode_extended.js
@@ -42,7 +42,10 @@ export class Zenith {
         startZenithMode() {
             Game.zenithTimer = false;
             document.getElementById("climbSpeedBar").style.display = "none"
-            document.getElementById("aiToggleButton").style.display = "none"
+            // Only hide AI button when actually in zenith mode
+            if (Game.settings.game.gamemode === "zenith") {
+                document.getElementById("aiToggleButton").style.display = "none"
+            }
             Game.pixi.CreateSpeedrunContainer()
             Game.pixi.StopSpeedrun()
             if(Game.settings.game.gamemode != "zenith") return


### PR DESCRIPTION
Fix `TypeError: Cannot read properties of undefined (reading 'hd')` and prevent the AI button from disappearing in Zen mode.

The `hd` error occurred because keybinds were incorrectly accessed from `settings.keybinds` instead of `settings.control`. The AI button disappeared in Zen mode because `startZenithMode()` was unconditionally hiding it, even when the game mode was not "zenith", causing it to vanish in custom Zen modes.

---
<a href="https://cursor.com/background-agent?bcId=bc-fe38960d-8dc1-4cf4-8056-b6a71ac4a428">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fe38960d-8dc1-4cf4-8056-b6a71ac4a428">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

